### PR TITLE
Limit length of generated acronym letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ $acronym = Str::of('hello world')->headline()->acronym(); // Returns 'H.W.'
 
 ```
 
+To limit the length of the generated acronym letters, you may add a third 'limit' parameter:
+
+```php
+use Illuminate\Support\Str;
+
+$acronym = Str::acronym('Hello World', '.', 3); // Returns 'H.W'
+$acronym = Str::of('hello world')->headline()->acronym(limit: 1); // Returns 'H'
+
+```
+
 ## Testing
 
 This package is using PhpUnit to unit test the macros. A simple alias has been created with composer to run the tests. 

--- a/src/StrServiceProvider.php
+++ b/src/StrServiceProvider.php
@@ -12,7 +12,7 @@ class StrServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        Str::macro('acronym', function ($string, $delimiter = '') {
+        Str::macro('acronym', function ($string, $delimiter = '', int $limit = null) {
             if (empty($string)) {
                 return '';
             }
@@ -28,8 +28,8 @@ class StrServiceProvider extends ServiceProvider
             return $acronym;
         });
 
-        Stringable::macro('acronym', function (string $delimiter = '') {
-            return new Stringable (Str::acronym($this->value, $delimiter));
+        Stringable::macro('acronym', function (string $delimiter = '', int $limit = null) {
+            return new Stringable (Str::acronym($this->value, $delimiter, $limit));
         });
     }
 }

--- a/src/StrServiceProvider.php
+++ b/src/StrServiceProvider.php
@@ -25,6 +25,11 @@ class StrServiceProvider extends ServiceProvider
                 }
             }
 
+            // Trim the acronym if limit has been provided
+            if ($limit !== null) {
+                $acronym = mb_substr($acronym, 0, $limit);
+            }
+
             return $acronym;
         });
 

--- a/tests/AcronymStrTest.php
+++ b/tests/AcronymStrTest.php
@@ -24,4 +24,18 @@ class AcronymStrTest extends TestCase
         $this->assertSame('ÉL', Str::acronym("Érico Leitão"));
         $this->assertSame('HW', (string) Str::of('hello world')->headline()->acronym());
     }
+
+    public function testAcronymWithLimit()
+    {
+        // Test cases with the limit parameter
+        $this->assertSame('li', Str::acronym('lorem ipsum dolor sit amet', limit: 2));
+        $this->assertSame('L', Str::acronym('Laravel is freaking everywhere', '', 1));
+        $this->assertSame('fB', Str::acronym('foo  Bar', '', 3)); // No truncation as it's within the limit
+        $this->assertSame('ts', Str::acronym('trailing spaces   ', '', 2));
+        $this->assertSame('ty', Str::acronym('the year 2013', '', 3));
+        $this->assertSame('lp', Str::acronym("laravel\t\tphp\n\nframework", limit: 2));
+        $this->assertSame('É', Str::acronym("Érico Leitão", '', 1));
+        $this->assertSame('HW', (string) Str::of('hello world')->headline()->acronym('', 2));
+    }
+
 }

--- a/tests/AcronymStringableTest.php
+++ b/tests/AcronymStringableTest.php
@@ -23,4 +23,10 @@ class AcronymStringableTest extends TestCase
         $this->assertSame('lidsa', (string) $this->stringable('lorem ipsum dolor sit amet')->acronym());
         $this->assertSame('l.i.d.s.a', (string) $this->stringable('lorem ipsum dolor sit amet')->acronym('.')->rtrim('.'));
     }
+
+    public function testAcronymWithLimit()
+    {
+        $this->assertSame('lid', (string) $this->stringable('lorem ipsum dolor sit amet')->acronym('', 3));
+        $this->assertSame('l.i', (string) $this->stringable('lorem ipsum dolor sit amet')->acronym('.', 3)->rtrim('.'));
+    }
 }


### PR DESCRIPTION
Just a nice optional addition to help limit the generated length.

Regards, Tom.